### PR TITLE
Fix #3

### DIFF
--- a/.yarn/versions/69a1fae4.yml
+++ b/.yarn/versions/69a1fae4.yml
@@ -1,0 +1,5 @@
+undecided:
+  - root
+  - agikit-vscode
+  - "@agikit/core"
+  - "@agikit/logic-language-server"

--- a/packages/core/src/Scripting/LogicScriptASTGenerator.ts
+++ b/packages/core/src/Scripting/LogicScriptASTGenerator.ts
@@ -57,7 +57,7 @@ export class LogicScriptASTGenerator {
     objectList: ObjectList,
   ) {
     this.parseTree = new LogicScriptParseTree(
-      simplifyLogicScriptProgram(parseTree.program),
+      simplifyLogicScriptProgram(parseTree),
       parseTree.identifiers,
     );
     this.wordList = wordList;

--- a/packages/core/src/Scripting/LogicScriptParser.ts
+++ b/packages/core/src/Scripting/LogicScriptParser.ts
@@ -25,9 +25,8 @@ export type LogicScriptStatementVisitor<StatementType extends LogicScriptStateme
   stack: LogicScriptStatementStack<StatementType>,
 ) => boolean;
 
-export type LogicScriptStatementStack<
-  StatementType extends LogicScriptStatement
-> = StatementType[][];
+export type LogicScriptStatementStack<StatementType extends LogicScriptStatement> =
+  StatementType[][];
 
 export type LogicScriptPreprocessedStatement =
   | Exclude<

--- a/packages/core/src/Scripting/__tests__/regression.test.ts
+++ b/packages/core/src/Scripting/__tests__/regression.test.ts
@@ -1,0 +1,45 @@
+import { parseLogicScript, parseLogicScriptRaw } from '../LogicScriptParser';
+import { LogicCompiler } from '../LogicCompiler';
+import { optimizeAST } from '../../Extract/Logic/ASTOptimization';
+import { LogicScriptASTGenerator } from '../LogicScriptASTGenerator';
+import { WordList } from '../../Types/WordList';
+import { ObjectList } from '../../Types/ObjectList';
+import { LogicCommand } from '../../Types/Logic';
+
+it('Issue #3: compiles to assignn or assignv depending on the value type, not the token type', () => {
+  const testScript = `
+  #define LITERAL   55
+  #define VARIABLE v55
+
+  v100 = 55;
+  v100 = LITERAL;
+  v100 = v55;
+  v100 = VARIABLE;
+  `;
+
+  const program = parseLogicScriptRaw(testScript, 'test.agilogic');
+  const parseTree = parseLogicScript(program, 'test.agilogic');
+  const astGenerator = new LogicScriptASTGenerator(parseTree, new Map(), {
+    maxAnimatedObjects: 0,
+    objects: [],
+  });
+  const root = astGenerator.generateASTForLogicScript();
+  const graph = optimizeAST(root);
+  const compiler = new LogicCompiler(graph, astGenerator.getLabels());
+  const { instructions } = compiler.compile();
+
+  const commands: LogicCommand[] = instructions.filter(
+    (instruction): instruction is LogicCommand => instruction.type === 'command',
+  );
+
+  expect(commands.map((command) => command.agiCommand.name)).toEqual([
+    'assignn',
+    'assignn',
+    'assignv',
+    'assignv',
+  ]);
+
+  commands.forEach((command) => {
+    expect(command.args).toEqual([100, 55]);
+  });
+});


### PR DESCRIPTION
Closes #3.

`simplifyLogicScriptStatement` was assuming that anything that's an identifier must be pointing at a variable, and therefore should use the `assignn` opcode.  But, identifiers can be `#define`d as constant values, which should use `assignv`.

Thanks @SandTAS for reporting this issue!